### PR TITLE
added image_url:string to items model

### DIFF
--- a/db/migrate/20210130144417_add_image_url_to_items.rb
+++ b/db/migrate/20210130144417_add_image_url_to_items.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_190030) do
+ActiveRecord::Schema.define(version: 2021_01_30_144417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2021_01_26_190030) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "image_url"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 


### PR DESCRIPTION
Items model now contains the column image_url datatype String

In preparation to enable users to create / update items with individual images using a cloudinary ID.